### PR TITLE
Adagrad, L2 regularization, log-loss, and beam-search parsing

### DIFF
--- a/arithmetic.py
+++ b/arithmetic.py
@@ -9,12 +9,12 @@ __email__ = "See the author's website"
 from collections import defaultdict
 from numbers import Number
 
-from domain import Domain
-from example import Example
-from experiment import evaluate_for_domain, evaluate_dev_examples_for_domain, train_test, train_test_for_domain, interact, learn_lexical_semantics, generate
-from metrics import DenotationAccuracyMetric
-from parsing import Grammar, Rule
-from scoring import rule_features
+from sippycup.domain import Domain
+from sippycup.example import Example
+from sippycup.experiment import evaluate_for_domain, evaluate_dev_examples_for_domain, train_test, train_test_for_domain, interact, learn_lexical_semantics, generate
+from sippycup.metrics import DenotationAccuracyMetric
+from sippycup.parsing import Grammar, Rule
+from sippycup.scoring import rule_features
 
 # ArithmeticDomain =============================================================
 

--- a/domain.py
+++ b/domain.py
@@ -30,8 +30,8 @@ __email__ = "See the author's website"
 
 from collections import defaultdict
 
-from metrics import standard_metrics, SemanticsAccuracyMetric
-from scoring import Model
+from sippycup.metrics import standard_metrics, SemanticsAccuracyMetric
+from sippycup.scoring import Model
 
 class Domain:
     def train_examples(self):

--- a/experiment.py
+++ b/experiment.py
@@ -9,11 +9,11 @@ __email__ = "See the author's website"
 from collections import defaultdict
 import random
 
-from metrics import SemanticsAccuracyMetric, NumParsesMetric, standard_metrics
-from example import Example
-from learning import latent_sgd
-from parsing import is_cat, parse_to_pretty_string, print_grammar
-from scoring import Model, rule_features
+from sippycup.metrics import SemanticsAccuracyMetric, NumParsesMetric, standard_metrics
+from sippycup.example import Example
+from sippycup.learning import latent_sgd
+from sippycup.parsing import is_cat, parse_to_pretty_string, print_grammar
+from sippycup.scoring import Model, rule_features
 
 # TODO: comment
 def print_sample_outcomes(model=None,

--- a/learning.py
+++ b/learning.py
@@ -10,8 +10,8 @@ import math
 import random
 from collections import defaultdict, Counter
 
-from metrics import SemanticsAccuracyMetric, DenotationAccuracyMetric
-from scoring import Model, score
+from sippycup.metrics import SemanticsAccuracyMetric, DenotationAccuracyMetric
+from sippycup.scoring import Model, score
 
 
 def latent_sgd(

--- a/learning.py
+++ b/learning.py
@@ -6,13 +6,60 @@ __version__ = "0.9"
 __maintainer__ = "Bill MacCartney"
 __email__ = "See the author's website"
 
+import math
 import random
-from collections import defaultdict
+from collections import defaultdict, Counter
 
 from metrics import SemanticsAccuracyMetric, DenotationAccuracyMetric
-from scoring import Model
+from scoring import Model, score
 
-def latent_sgd(model=None, examples=[], training_metric=None, T=10, eta=0.1, seed=None):
+
+def latent_sgd(
+        model,
+        examples,
+        training_metric,
+        T=10,
+        eta=0.1,
+        seed=None,
+        beam_search=False,
+        loss='hinge',
+        l2_penalty=0.0,
+        epsilon=1e-7):
+    """
+    Parameters
+    ----------
+    model : `scoring.Model`
+    examples : iterable of `example.Example`
+    training_metric : `metric.Metric`
+    T : int
+        Maximum number of training instances. This can be cut short
+        if the error or AdaGrad magnitude drop below `epsilon`.
+    eta : float
+        Learning rate
+    seed : int or None
+        Use to fix the randomization in how examples are shuffled and
+        ties are decided.
+    beam_search : bool
+        Whether to use beam search. If `True`, then cells in the chart
+        parse are filled with the top scoring (sub)parses according to
+        the current model. If `False`, they are falled with a random
+        sample of (sub)parses. The beam/sample size is set by
+        `parsing.MAX_CELL_CAPACITY`.
+    loss : str
+        Either 'hinge' or 'log'.
+    l2_penalty : float
+        L2 penalty constant to apply to each weight. If 0.0, then
+        no penalty is imposed. Larger weights correspond to a stronger
+        penalty.
+    epsilon : float
+        Tolerance for stopping learning. If either the total error
+        or the adagrad magnitude drops below this, then learning
+        is terminated.
+
+    Returns
+    -------
+    Trained `scoring.Model` instance.
+    """
     # Used for sorting scored parses.
     def scored_parse_key_fn(scored_parse):
         return (scored_parse[0], str(scored_parse[1]))
@@ -25,26 +72,50 @@ def latent_sgd(model=None, examples=[], training_metric=None, T=10, eta=0.1, see
         print('random.seed(%d)' % seed)
         random.seed(seed)
     model = clone_model(model)
+    adagrad = defaultdict(float)
+    # No margin cost for log-loss objective:
+    costfunc = cost if loss == 'hinge' else (lambda x, y : 0.0)
     for t in range(T):
         random.shuffle(examples)
         num_correct = 0
+        ada_update_mag = 0.0
+        error = 0.0
         for example in examples:
+            # Scoring to define the beam:
+            scorer = None
+            if beam_search:
+                scorer = (lambda p : score(p, model.feature_fn, model.weights))
             # Reparse with current weights.
-            parses = model.parse_input(example.input)
+            parses = model.parse_input(example.input, scorer=scorer)
             # Get the highest-scoring "good" parse among the candidate parses.
             good_parses = [p for p in parses if training_metric.evaluate(example, [p])]
             if good_parses:
                 target_parse = good_parses[0]
                 # Get all (score, parse) pairs.
-                scores = [(p.score + cost(target_parse, p), p) for p in parses]
+                scores = [(p.score + costfunc(target_parse, p), p) for p in parses]
                 # Get the maximal score.
                 max_score = sorted(scores, key=scored_parse_key_fn)[-1][0]
+                # Error:
+                error += max_score - target_parse.score
                 # Get all the candidates with the max score and choose one randomly.
                 predicted_parse = random.choice([p for s, p in scores if s == max_score])
                 if training_metric.evaluate(example, [predicted_parse]):
                     num_correct += 1
-                update_weights(model, target_parse, predicted_parse, eta)
-        print('SGD iteration %d: train accuracy: %.3f' % (t, 1.0 * num_correct / len(examples)))
+                ada_update_mag, adagrad = update_weights(
+                    model,
+                    target_parse,
+                    predicted_parse,
+                    eta,
+                    l2_penalty,
+                    loss, adagrad,
+                    ada_update_mag)
+        acc = 1.0 * num_correct / len(examples)
+        print('SGD iteration {0:}; '
+                  'error {1:0.07f}; '
+                  'AdaGrad magnitude {2:0.07f}; '
+                  'train accuracy {3:0.04f}'.format(t, error, ada_update_mag, acc))
+        if error < epsilon or ada_update_mag < epsilon:
+            break
     print_weights(model.weights)
     return model
 
@@ -57,15 +128,31 @@ def clone_model(model):
                  weights=defaultdict(float),  # Zero the weights.
                  executor=model.executor)
 
-def update_weights(model, target_parse, predicted_parse, eta):
+def update_weights(model, target_parse, predicted_parse, eta, l2_penalty, loss, adagrad, ada_update_mag):
     target_features = model.feature_fn(target_parse)
     predicted_features = model.feature_fn(predicted_parse)
-    for f in set(list(target_features.keys()) + list(predicted_features.keys())):
-        update = target_features[f] - predicted_features[f]
-        if update != 0.0:
-            # print 'update %g + %g * %g = %g\t%s' % (
-            #     model.weights[f], eta, update, model.weights[f] + eta * update, f)
-            model.weights[f] += eta * update
+    all_f = set(target_features.keys()) | set(predicted_features.keys())
+    # Gradient:
+    grad = defaultdict(float)
+    if loss == 'hinge':
+        for f in all_f:
+            grad[f] = target_features[f] - predicted_features[f]
+    else: # This is the log-loss:
+        grad = Counter(target_features)
+        grad.subtract(predicted_features)
+    # L2 penalty:
+    for f, w in model.weights.items():
+        grad[f] -= l2_penalty * w
+    # Adaptive gradient update:
+    for f, w in grad.items():
+        adagrad[f] += grad[f]**2
+        ada_decay = math.sqrt(adagrad[f])
+        if ada_decay != 0.0:
+            dw = eta * (grad[f] / ada_decay)
+            model.weights[f] += dw
+            ada_update_mag += dw**2
+    return (ada_update_mag, adagrad)
+
 
 def print_weights(weights, n=20):
     pairs = [(value, str(key)) for key, value in list(weights.items()) if value != 0]

--- a/scoring.py
+++ b/scoring.py
@@ -44,17 +44,17 @@ class Model:
         self.executor = executor
 
     # TODO: Should this become a static function, to match style of parsing.py?
-    def parse_input(self, input, get_chart=False):
+    def parse_input(self, input, get_chart=False, scorer=None):
         if get_chart:
-            parses, chart = self.grammar.parse_input(input, get_chart=get_chart)
+            parses, chart = self.grammar.parse_input(input, get_chart=get_chart, scorer=scorer)
         else:
-            parses = self.grammar.parse_input(input, get_chart=get_chart)
+            parses = self.grammar.parse_input(input, get_chart=get_chart, scorer=scorer)
 
         for parse in parses:
             if self.executor:
                 parse.denotation = self.executor(parse.semantics)
             parse.score = score(parse, self.feature_fn, self.weights)
-        
+
         parses = sorted(parses, key=lambda parse: parse.score, reverse=True)
         if get_chart:
             return parses, chart


### PR DESCRIPTION
Hey @reschkek,

This PR is for core optimization improvements to SippyCup. I managed to do everything I wanted, but this is really straining SippyCup, which has baked in a lot of stuff that should be abstracted out, and its inconsistent use of object-orientation makes everything hard to keep track of. I press on:

The core task was to allow beam search during parsing. These changes are pretty straightforward. They are in `parsing.py`. The new pieces are just that `parse_input` and its subfunctions take an optional `scorer` parameter. This needs to map `Parse` objects to floats. In turn, `Grammar.parse_input` also takes a `scorer` parameter, which is just passed to the module `parse_input`.

At present, the beam size is determined by `parsing.MAX_CELL_CAPACITY`. This is opportunistic, but it works, and I couldn't bear to add more parameters.

I also updated `learning.py`. `latent_sgd` now supports the log loss as well as the old hinge loss. I also added L2 regularization and AdaGrad. AdaGrad seems to help a ton. I also wove beam_search into this function.

All of this is needlessly complicated, but it works. With all the old default parameters, the behavior should be exactly as it was before I made these changes, with one small exception: if beam search is not used during parsing, the cells get filled with a random sample of the parses for that span. Before, it was like the first `parsing.MAX_CELL_CAPACITY` parses, which is impossible to justify, as far as I can tell.

I'll shortly check in some notebooks to `suggestion_engine.develop` that provide some tests and examples of how this all fits together.