### PR TITLE
Fix non-branching bug

### DIFF
--- a/parsing.py
+++ b/parsing.py
@@ -366,11 +366,11 @@ def apply_unary_rules(grammar, chart, i, j, scorer=None):
     # essentially get unary closure "for free".  (However, if the grammar
     # contains unary cycles, we'll get stuck in a loop, which is one reason for
     # check_capacity().)
-    parses = []
     for parse in chart[(i, j)]:
+        parses = []
         for rule in grammar.unary_rules[(parse.rule.lhs,)]:
             safe_add_parse_to_list(parses, rule, [parse])
-    add_parses_to_chart(chart, i, j, parses, scorer=scorer)
+        add_parses_to_chart(chart, i, j, parses, scorer=scorer)
 
 # Important for catching e.g. unary cycles.
 max_cell_capacity_hits = 0


### PR DESCRIPTION
@reschkek Here's a fix for the non-branching bug you found ([Jira link](https://roaminsight.atlassian.net/browse/SE-6?focusedCommentId=19511&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-19511)) The answer was basically right there in Bill's comment inside the method!

SippyCup needs a testing framework. I don't have time to set that up right now, but here's an informal test that shows that this kind of branching now works:

```python
from parsing import Grammar, Rule, add_rule, Parse
from parsing import parse_input

gram = Grammar(start_symbol='$E')

for w in ['zero', 'one', 'two']:
    add_rule(gram, Rule('$N0', w))

for p in ['plus', 'minus']:
    add_rule(gram, Rule('$BinOp', p))

add_rule(gram, Rule('$N1', '$N0'))
add_rule(gram, Rule('$E', '$N1'))
add_rule(gram, Rule('$EBO', '$E $BinOp'))
add_rule(gram, Rule('$E', '$EBO $E'))

print(gram.parse_input('two plus two')[0])
```