### PR TITLE
allow user to pass scoring model.

### DIFF
--- a/scoring.py
+++ b/scoring.py
@@ -59,7 +59,11 @@ class Model:
         for parse in parses:
             if self.executor:
                 parse.denotation = self.executor(parse.semantics)
-            parse.score = score(parse, self.feature_fn, self.weights)
+            if scorer:
+                parse.score = scorer(parse)
+            # If no scorer passed, back-off to default inner product scorer
+            else:
+                parse.score = score(parse, self.feature_fn, self.weights)
 
         parses = sorted(parses, key=lambda parse: parse.score, reverse=True)
         if get_chart:


### PR DESCRIPTION
@reschkek this addition allows us to pass custom scoring models to sippycup and is a part of the larger [incorporating learned parse-rank models initiative](https://github.com/roaminsight/suggestion-engine/pull/129/).